### PR TITLE
chore(README): add example for end scroll event

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,27 @@ void main() => runApp(const MyApp());
 
 For more advanced usage, you can also mount controllers, making them shift each other. See [example](example/lib/main.dart).
 
+### Example: Listening for the scroll end event
+
+```dart
+const daysOfWeek = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
+
+return NotificationListener(
+  onNotification: (notification) {
+    if (notification is ScrollEndNotification) {
+      print('User has ended scrolling');
+    }
+    return false;
+  },
+  child: WheelPicker(
+    itemCount: 7,
+    builder: (context, index) => Text(daysOfWeek[index]),
+    selectedIndexColor: Colors.orange,
+    looping: false,
+  ),
+);
+```
+
 <br />
 <br />
 


### PR DESCRIPTION
Hello! Thank you for your Flutter package. I encountered a situation where I needed to detect when the user has finished scrolling in order to trigger a method. The onIndexChanged callback is invoked during every scroll event, which doesn’t quite fit my use case. I suggest adding an example demonstrating how to handle this scenario so others can benefit as well.